### PR TITLE
Address entityをfreezedで作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# board_buff ignore
+**.g.dart
+**.freezed.dart
+
 # Miscellaneous
 *.class
 *.log

--- a/lib/address.dart
+++ b/lib/address.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'address.freezed.dart';
+part 'address.g.dart';
+
+@freezed
+abstract class Address with _$Address {
+  factory Address({
+    @JsonKey(name: 'address1') required String address1,
+    @JsonKey(name: 'address2') required String address2,
+    @JsonKey(name: 'address3') required String address3,
+  }) = _Address;
+  Address._();
+
+  factory Address.fromJson(Map<String, dynamic> json) =>
+      _$AddressFromJson(json);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -278,12 +278,19 @@ packages:
     source: hosted
     version: "0.6.4"
   json_annotation:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.4.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.6"
   lints:
     dependency: transitive
     description:
@@ -394,6 +401,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.2"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.2"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,8 @@ dev_dependencies:
   build_runner:
   freezed_annotation:
   freezed:
+  json_serializable:
+  json_annotation:
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
freezedを使ってentityを生成できるようにしました。
pub getのあとに以下を実行して生成してください
```
fvm flutter pub run build_runner build
```


pubspec.yamlを修正したのは
```
[WARNING] json_serializable:json_serializable on lib/address.dart:
You are missing a required dependency on json_annotation in the "dependencies" section of your pubspec with a lower bound of at least "4.4.0".
[INFO] Running build completed, took 2.3s

[INFO] Caching finalized dependency graph...
[INFO] Caching finalized dependency graph completed, took 38ms

[INFO] Succeeded after 2.4s with 3 outputs (3 actions)
```
のようなエラーが発生していたからです。
最後の行のSucceededしか見ていませんでしたが、実際はwarningでjson_annotationを追加してくれといわれていました。

fvmを使うと色がつかないので、このようなことが発生しやすくなるかもしれませんね
