### PR TITLE
chore: tweak git ignore

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "3.0.4",
+  "flavors": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # board_buff ignore
-**.g.dart
-**.freezed.dart
+*.g.dart
+*.freezed.dart
+.fvm/flutter_sdk
 
 # Miscellaneous
 *.class


### PR DESCRIPTION
git 2.37.0でfreezedファイルがignoreされない事象があった為ルールを変更
fvm以下のsdkをignore